### PR TITLE
Switch plistlib to py3.4+ API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'untp',
-    version = '2.0.0',
+    version = '2.0.1',
     description = 'A command line tool to split TexturePacker published files.',
     url = 'https://github.com/neobenedict/untp',
     author = 'justbilt, neobenedict',

--- a/src/untp/dataparse.py
+++ b/src/untp/dataparse.py
@@ -5,7 +5,7 @@
 import os
 import json
 from parse import parse
-from plistlib import readPlist
+import plistlib
 from pprint import pprint
 
 def parse_file(_filepath, _config=None, _extra_data_receiver=None):
@@ -13,7 +13,8 @@ def parse_file(_filepath, _config=None, _extra_data_receiver=None):
 	pre,ext = os.path.splitext(name)
 	if ext == ".plist":
 		try:
-			data = readPlist(_filepath)
+			with open(_filepath, 'rb') as f:
+				data = plistlib.load(f)
 		except Exception:
 			print("fail: read plist file failed >", _filepath)
 			return

--- a/tests/test_untp.py
+++ b/tests/test_untp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python  
 # coding=utf-8  
-# Python 2.7.3
+# Python 3.4.10
 
 
 import unittest
@@ -31,7 +31,8 @@ class TestUnpackPlist(unittest.TestCase):
 			shutil.rmtree(TEMP_PATH)
 
 	def _test_unpack(self, _plist, _output, _size_field="{sourceSize}"):
-		data = plistlib.readPlist(_plist)
+		with open(_plist, 'rb') as f:
+			data = plistlib.load(f)
 		for k,v in data.frames.iteritems():
 			clip_path = os.path.join(_output, k)
 			self.assertTrue(os.path.exists(clip_path))


### PR DESCRIPTION
Tested with python-3.9.6 and python-3.10.0_rc1

[plistlib docs](https://docs.python.org/3.8/library/plistlib.html) describing deprecated (dropped in 3.9) functions from py3.4 and their replacements.

